### PR TITLE
Make progressive JPEGs work on Android

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -206,7 +206,7 @@
     "jpeg",
     "rgb"
   ]
-  revision = "f5e7749c1ab5e13b209ab2eaaa2e17b6eeee7045"
+  revision = "70c8b83ed7e0c5b8e807cf4e0e9b8e4e20082bb3"
 
 [[projects]]
   branch = "master"
@@ -389,6 +389,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e0d59a1ad06812bc0e22ff2b8ef7022a942b29ae10a5d93fee2467238aad1ce9"
+  inputs-digest = "380f1c05f050a80aef7d81ea947a3c64d4f76a32338c8a491aa80d9183d513bf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Homebrew on macOS provides `libjpeg-turbo` and `opencv`. They can be used in the
 export CGO_CPPFLAGS="-I/usr/local/Cellar/opencv/3.4.1_2/include -I/usr/local/Cellar/opencv/3.4.1_2/include/opencv2"
 export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
 export CGO_CFLAGS="-I/usr/local/opt/jpeg-turbo/include"
-export CGO_LDFLAGS="-L/usr/local/Cellar/opencv/3.4.1_2/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking-L/usr/local/opt/jpeg-turbo/lib"
+export CGO_LDFLAGS="-L/usr/local/Cellar/opencv/3.4.1_2/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking -L/usr/local/opt/jpeg-turbo/lib"
 go install github.com/richiefi/imageproxy/cmd/imageproxy
 imageproxy
 ```


### PR DESCRIPTION
mozjpeg's default configuration for progressive JPEG creation does not work well with old Android. 

The actual change is in `vendor` directory, since libjpeg binding is in a different repo.